### PR TITLE
Add checks for list structure, create utility method to replace Deck.toString(), etc.

### DIFF
--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -650,6 +650,7 @@ public class Tester {
       "assignment2.Deck_Deck_too_many_suits",
       "assignment2.Deck_Deck_too_few_suits",
       "assignment2.Deck_Deck_copy",
+      "assignment2.Deck_Deck_deep_copy",
       "assignment2.Deck_numOfCards",
       "assignment2.Deck_shuffle",
       "assignment2.Deck_locate_joker",

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -515,6 +515,9 @@ class Deck_count_cut_no_change_1 implements Runnable {
       throw new AssertionError(
           "The resulting deck is " + result + " but should have been " + expected);
     }
+
+    Tester.checkReferences(deck);
+
     System.out.println("Deck count cut no change test 1 passed.");
   }
 }
@@ -534,6 +537,9 @@ class Deck_count_cut_no_change_2 implements Runnable {
       throw new AssertionError(
           "The resulting deck is " + result + " but should have been " + expected);
     }
+
+    Tester.checkReferences(deck);
+
     System.out.println("Deck count cut no change test 2 passed.");
   }
 }
@@ -553,6 +559,9 @@ class Deck_count_cut_with_change implements Runnable {
       throw new AssertionError(
           "The resulting deck is " + result + " but should have been " + expected);
     }
+
+    Tester.checkReferences(deck);
+
     System.out.println("Deck count cut with change test passed.");
   }
 }

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -215,6 +215,9 @@ class Deck_shuffle implements Runnable {
       throw new AssertionError(
           "The shuffled deck is " + result + " but should have been " + expected);
     }
+
+    Tester.checkReferences(deck);
+
     System.out.println("Deck shuffle test passed.");
   }
 }

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -617,7 +617,7 @@ public class Tester {
   static String[] tests = {
       "assignment2.Deck_Deck_one_card",
       "assignment2.Deck_Deck_all_cards",
-      "assignment2.Deck_Deck_all_cards",
+      "assignment2.Deck_Deck_references",
       "assignment2.Deck_Deck_too_many_cards",
       "assignment2.Deck_Deck_too_few_cards",
       "assignment2.Deck_Deck_too_many_suits",

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -133,6 +133,9 @@ class Deck_Deck_copy implements Runnable {
       throw new AssertionError(
           "new Deck(new Deck(13, 4)) returned " + result + " but expected " + expected);
     }
+
+    Tester.checkReferences(deckCopy);
+
     System.out.println("Deck copy test passed.");
   }
 }

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -392,6 +392,22 @@ class Deck_move_card_with_change implements Runnable {
 }
 
 
+class Deck_move_card_references implements Runnable {
+  @Override
+  public void run() {
+    Deck deck = new Deck(5, 2);
+    Deck.gen.setSeed(10);
+    deck.shuffle();
+    deck.moveCard(deck.locateJoker("red"), 1);
+    deck.moveCard(deck.locateJoker("black"), 2);
+
+    Tester.checkReferences(deck);
+
+    System.out.println("Deck moveCard() references test passed.");
+  }
+}
+
+
 class Deck_triple_cut_regular implements Runnable {
   @Override
   public void run() {
@@ -681,6 +697,7 @@ public class Tester {
       "assignment2.Deck_locate_joker_no_jokers",
       "assignment2.Deck_move_card_no_change",
       "assignment2.Deck_move_card_with_change",
+      "assignment2.Deck_move_card_references",
       "assignment2.Deck_triple_cut_regular",
       "assignment2.Deck_triple_cut_empty_end",
       "assignment2.Deck_triple_cut_empty_start",

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -26,13 +26,21 @@ class Deck_Deck_all_cards implements Runnable {
   public void run() {
     Deck deck = new Deck(13, 4);
     String result = deck.toString();
-    String expected =
-        "AC 2C 3C 4C 5C 6C 7C 8C 9C 10C JC QC KC AD 2D 3D 4D 5D 6D 7D 8D 9D 10D JD QD KD AH 2H 3H 4H 5H 6H 7H 8H 9H 10H JH QH KH AS 2S 3S 4S 5S 6S 7S 8S 9S 10S JS QS KS RJ BJ";
+    String expected = "AC 2C 3C 4C 5C 6C 7C 8C 9C 10C JC QC KC AD 2D 3D 4D 5D 6D 7D 8D 9D 10D JD QD KD AH 2H 3H 4H 5H 6H 7H 8H 9H 10H JH QH KH AS 2S 3S 4S 5S 6S 7S 8S 9S 10S JS QS KS RJ BJ";
 
     if (!result.equals(expected)) {
       throw new AssertionError("new Deck(13, 4) returned " + result + " but expected " + expected);
     }
     System.out.println("All cards deck test passed.");
+  }
+}
+
+class Deck_Deck_references implements Runnable {
+  @Override
+  public void run() {
+    Deck deck = new Deck(13, 4);
+    Tester.checkReferences(deck);
+    System.out.println("Deck() references test passed");
   }
 }
 
@@ -57,21 +65,21 @@ class Deck_Deck_too_many_cards implements Runnable {
 
 
 class Deck_Deck_too_few_cards implements Runnable {
-	@Override
-	public void run() {
-		boolean thrown = false;
-		try {
-			new Deck(0, 4);
-		} catch (IllegalArgumentException expected) {
-			thrown = true;
-		}
+  @Override
+  public void run() {
+    boolean thrown = false;
+    try {
+      new Deck(0, 4);
+    } catch (IllegalArgumentException expected) {
+      thrown = true;
+    }
 
-		if (!thrown) {
-			throw new AssertionError("new Deck(0, 4) did not throw an IllegalArgumentException");
-		} else {
-			System.out.println("Too few cards deck test passed.");
-		}
-	}
+    if (!thrown) {
+      throw new AssertionError("new Deck(0, 4) did not throw an IllegalArgumentException");
+    } else {
+      System.out.println("Too few cards deck test passed.");
+    }
+  }
 }
 
 
@@ -95,21 +103,21 @@ class Deck_Deck_too_many_suits implements Runnable {
 
 
 class Deck_Deck_too_few_suits implements Runnable {
-	@Override
-	public void run() {
-		boolean thrown = false;
-		try {
-			new Deck(13, 0);
-		} catch (IllegalArgumentException expected) {
-			thrown = true;
-		}
+  @Override
+  public void run() {
+    boolean thrown = false;
+    try {
+      new Deck(13, 0);
+    } catch (IllegalArgumentException expected) {
+      thrown = true;
+    }
 
-		if (!thrown) {
-			throw new AssertionError("new Deck(13, 0) did not throw an IllegalArgumentException");
-		} else {
-			System.out.println("Too few suits deck test passed.");
-		}
-	}
+    if (!thrown) {
+      throw new AssertionError("new Deck(13, 0) did not throw an IllegalArgumentException");
+    } else {
+      System.out.println("Too few suits deck test passed.");
+    }
+  }
 }
 
 
@@ -119,8 +127,7 @@ class Deck_Deck_copy implements Runnable {
     Deck originalDeck = new Deck(13, 4);
     Deck deckCopy = new Deck(originalDeck);
     String result = deckCopy.toString();
-    String expected =
-        "AC 2C 3C 4C 5C 6C 7C 8C 9C 10C JC QC KC AD 2D 3D 4D 5D 6D 7D 8D 9D 10D JD QD KD AH 2H 3H 4H 5H 6H 7H 8H 9H 10H JH QH KH AS 2S 3S 4S 5S 6S 7S 8S 9S 10S JS QS KS RJ BJ";
+    String expected = "AC 2C 3C 4C 5C 6C 7C 8C 9C 10C JC QC KC AD 2D 3D 4D 5D 6D 7D 8D 9D 10D JD QD KD AH 2H 3H 4H 5H 6H 7H 8H 9H 10H JH QH KH AS 2S 3S 4S 5S 6S 7S 8S 9S 10S JS QS KS RJ BJ";
 
     if (!result.equals(expected)) {
       throw new AssertionError(
@@ -517,7 +524,7 @@ class Deck_generate_next_keystream_value implements Runnable {
     Deck.gen.setSeed(10);
     deck.shuffle();
     int[] results = new int[12];
-    int[] expected = {4, 4, 15, 3, 3, 2, 1, 14, 16, 17, 17, 14};
+    int[] expected = { 4, 4, 15, 3, 3, 2, 1, 14, 16, 17, 17, 14 };
 
     for (int i = 0; i < 12; i++) {
       results[i] = deck.generateNextKeystreamValue();
@@ -540,7 +547,7 @@ class SolitaireCipher_get_keystream implements Runnable {
     deck.shuffle();
     SolitaireCipher solitaireCipher = new SolitaireCipher(deck);
     int[] results = solitaireCipher.getKeystream(12);
-    int[] expected = {4, 4, 15, 3, 3, 2, 1, 14, 16, 17, 17, 14};
+    int[] expected = { 4, 4, 15, 3, 3, 2, 1, 14, 16, 17, 17, 14 };
 
     if (!Arrays.equals(results, expected)) {
       throw new AssertionError("The resulting keystream values are " + Arrays.toString(results)
@@ -608,35 +615,36 @@ class SolitaireCipher_decode_secret_message implements Runnable {
 
 public class Tester {
   static String[] tests = {
-			"assignment2.Deck_Deck_one_card",
-			"assignment2.Deck_Deck_all_cards",
-			"assignment2.Deck_Deck_too_many_cards",
-			"assignment2.Deck_Deck_too_few_cards",
-			"assignment2.Deck_Deck_too_many_suits",
-			"assignment2.Deck_Deck_too_few_suits",
-			"assignment2.Deck_Deck_copy",
-			"assignment2.Deck_numOfCards",
-			"assignment2.Deck_shuffle",
-			"assignment2.Deck_locate_joker",
-			"assignment2.Deck_locate_joker_top_or_bottom_cards",
-			"assignment2.Deck_locate_joker_no_jokers",
-			"assignment2.Deck_move_card_no_change",
-			"assignment2.Deck_move_card_with_change",
-			"assignment2.Deck_triple_cut_regular",
-			"assignment2.Deck_triple_cut_empty_end",
-			"assignment2.Deck_triple_cut_empty_start",
-			"assignment2.Deck_triple_cut_both_ends_empty",
-			"assignment2.Deck_count_cut_no_change_1",
-			"assignment2.Deck_count_cut_no_change_2",
-			"assignment2.Deck_count_cut_with_change",
-			"assignment2.Deck_look_up_card_joker",
-			"assignment2.Deck_look_up_card_regular",
-			"assignment2.Deck_generate_next_keystream_value",
-			"assignment2.SolitaireCipher_get_keystream",
-			"assignment2.SolitaireCipher_encode",
-			"assignment2.SolitaireCipher_decode",
-			"assignment2.SolitaireCipher_decode_secret_message"
-	};
+      "assignment2.Deck_Deck_one_card",
+      "assignment2.Deck_Deck_all_cards",
+      "assignment2.Deck_Deck_all_cards",
+      "assignment2.Deck_Deck_too_many_cards",
+      "assignment2.Deck_Deck_too_few_cards",
+      "assignment2.Deck_Deck_too_many_suits",
+      "assignment2.Deck_Deck_too_few_suits",
+      "assignment2.Deck_Deck_copy",
+      "assignment2.Deck_numOfCards",
+      "assignment2.Deck_shuffle",
+      "assignment2.Deck_locate_joker",
+      "assignment2.Deck_locate_joker_top_or_bottom_cards",
+      "assignment2.Deck_locate_joker_no_jokers",
+      "assignment2.Deck_move_card_no_change",
+      "assignment2.Deck_move_card_with_change",
+      "assignment2.Deck_triple_cut_regular",
+      "assignment2.Deck_triple_cut_empty_end",
+      "assignment2.Deck_triple_cut_empty_start",
+      "assignment2.Deck_triple_cut_both_ends_empty",
+      "assignment2.Deck_count_cut_no_change_1",
+      "assignment2.Deck_count_cut_no_change_2",
+      "assignment2.Deck_count_cut_with_change",
+      "assignment2.Deck_look_up_card_joker",
+      "assignment2.Deck_look_up_card_regular",
+      "assignment2.Deck_generate_next_keystream_value",
+      "assignment2.SolitaireCipher_get_keystream",
+      "assignment2.SolitaireCipher_encode",
+      "assignment2.SolitaireCipher_decode",
+      "assignment2.SolitaireCipher_decode_secret_message"
+  };
 
   public static void main(String[] args) {
     int numPassed = 0;
@@ -645,8 +653,7 @@ public class Tester {
       System.out.printf("%n======= %s =======%n", className);
       System.out.flush();
       try {
-        Runnable testCase =
-            (Runnable) Class.forName(className).getDeclaredConstructor().newInstance();
+        Runnable testCase = (Runnable) Class.forName(className).getDeclaredConstructor().newInstance();
         testCase.run();
         numPassed++;
       } catch (AssertionError e) {
@@ -668,5 +675,34 @@ public class Tester {
     if (numPassed == tests.length) {
       System.out.println("All clear! Now get some rest.");
     }
+  }
+
+  // Utility methods
+
+  /**
+   * Checks that the given deck has consistent references (i.e. card ==
+   * card.next.prev for all cards) and loops around to the head only after
+   * traversing all cards. If not, throws an AssertionError detailing the issue.
+   * 
+   * @param deck The deck to be checked
+   */
+  public static void checkReferences(Deck deck) {
+    Deck.Card currentCard = deck.head;
+
+    for (int i = 0; i < deck.numOfCards; i++) {
+      // Check that references with the next node are consistent
+      if (currentCard != currentCard.next.prev)
+        throw new AssertionError("The links between card " + i + " and card " + (i + 1) + " are inconsistent.");
+
+      // Check that the list hasn't looped back to the head prematurely
+      if (currentCard.next == deck.head && i != deck.numOfCards - 1)
+        throw new AssertionError("The list looped back to the head prematurely.");
+
+      currentCard = currentCard.next;
+    }
+
+    // Check that the list looped back to the head
+    if (currentCard != deck.head)
+      throw new AssertionError("The list did not loop back to the head after traversing all cards.");
   }
 }

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -10,7 +10,7 @@ class Deck_Deck_one_card implements Runnable {
   @Override
   public void run() {
     Deck deck = new Deck(1, 1);
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "AC RJ BJ";
 
     if (!result.equals(expected)) {
@@ -25,7 +25,7 @@ class Deck_Deck_all_cards implements Runnable {
   @Override
   public void run() {
     Deck deck = new Deck(13, 4);
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "AC 2C 3C 4C 5C 6C 7C 8C 9C 10C JC QC KC AD 2D 3D 4D 5D 6D 7D 8D 9D 10D JD QD KD AH 2H 3H 4H 5H 6H 7H 8H 9H 10H JH QH KH AS 2S 3S 4S 5S 6S 7S 8S 9S 10S JS QS KS RJ BJ";
 
     if (!result.equals(expected)) {
@@ -126,7 +126,7 @@ class Deck_Deck_copy implements Runnable {
   public void run() {
     Deck originalDeck = new Deck(13, 4);
     Deck deckCopy = new Deck(originalDeck);
-    String result = deckCopy.toString();
+    String result = Tester.deckToString(deckCopy);
     String expected = "AC 2C 3C 4C 5C 6C 7C 8C 9C 10C JC QC KC AD 2D 3D 4D 5D 6D 7D 8D 9D 10D JD QD KD AH 2H 3H 4H 5H 6H 7H 8H 9H 10H JH QH KH AS 2S 3S 4S 5S 6S 7S 8S 9S 10S JS QS KS RJ BJ";
 
     if (!result.equals(expected)) {
@@ -134,6 +134,33 @@ class Deck_Deck_copy implements Runnable {
           "new Deck(new Deck(13, 4)) returned " + result + " but expected " + expected);
     }
     System.out.println("Deck copy test passed.");
+  }
+}
+
+
+/*
+ * Checks that Deck(Deck d) produces a deep copy of d (i.e. changing d does not
+ * affect the copy)
+ */
+class Deck_Deck_deep_copy implements Runnable {
+  @Override
+  public void run() {
+    Deck d = new Deck(13, 4);
+    Deck deckCopy = new Deck(d);
+    String expected = "AC 2C 3C 4C 5C 6C 7C 8C 9C 10C JC QC KC AD 2D 3D 4D 5D 6D 7D 8D 9D 10D JD QD KD AH 2H 3H 4H 5H 6H 7H 8H 9H 10H JH QH KH AS 2S 3S 4S 5S 6S 7S 8S 9S 10S JS QS KS RJ BJ";
+    String received;
+
+    // Change order of d
+    d.moveCard(d.head, 2);
+    received = Tester.deckToString(deckCopy);
+    if (!expected.equals(received))
+      throw new AssertionError("The copied deck was changed when the original deck was changed");
+
+    // Modify a card within d
+    ((Deck.PlayingCard) d.head).rank++;
+    received = Tester.deckToString(deckCopy);
+    if (!expected.equals(received))
+      throw new AssertionError("The copied deck was changed when the original deck was changed");
   }
 }
 
@@ -159,7 +186,7 @@ class Deck_shuffle implements Runnable {
     Deck deck = new Deck(5, 2);
     Deck.gen.setSeed(10);
     deck.shuffle();
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "3C 3D AD 5C BJ 2C 2D 4D AC RJ 4C 5D";
 
     if (!result.equals(expected)) {
@@ -312,7 +339,7 @@ class Deck_move_card_no_change implements Runnable {
     deck.shuffle();
     deck.moveCard(deck.locateJoker("red"), 0);
     deck.moveCard(deck.locateJoker("black"), 0);
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "3C 3D AD 5C BJ 2C 2D 4D AC RJ 4C 5D";
 
     if (!result.equals(expected)) {
@@ -331,7 +358,7 @@ class Deck_move_card_with_change implements Runnable {
     deck.shuffle();
     deck.moveCard(deck.locateJoker("red"), 1);
     deck.moveCard(deck.locateJoker("black"), 2);
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "3C 3D AD 5C 2C 2D BJ 4D AC 4C RJ 5D";
 
     if (!result.equals(expected)) {
@@ -350,7 +377,7 @@ class Deck_triple_cut_regular implements Runnable {
     Deck.gen.setSeed(10);
     deck.shuffle();
     deck.tripleCut(deck.locateJoker("black"), deck.locateJoker("red"));
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "4C 5D BJ 2C 2D 4D AC RJ 3C 3D AD 5C";
 
     if (!result.equals(expected)) {
@@ -370,7 +397,7 @@ class Deck_triple_cut_empty_end implements Runnable {
     deck.shuffle();
     deck.moveCard(deck.locateJoker("red"), 2);
     deck.tripleCut(deck.locateJoker("black"), deck.locateJoker("red"));
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "BJ 2C 2D 4D AC 4C 5D RJ 3C 3D AD 5C";
 
     if (!result.equals(expected)) {
@@ -390,7 +417,7 @@ class Deck_triple_cut_empty_start implements Runnable {
     deck.shuffle();
     deck.head = deck.locateJoker("black");
     deck.tripleCut(deck.locateJoker("black"), deck.locateJoker("red"));
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "4C 5D 3C 3D AD 5C BJ 2C 2D 4D AC RJ";
 
     if (!result.equals(expected)) {
@@ -411,7 +438,7 @@ class Deck_triple_cut_both_ends_empty implements Runnable {
     deck.moveCard(deck.locateJoker("red"), 6);
     deck.head = deck.locateJoker("black");
     deck.tripleCut(deck.locateJoker("black"), deck.locateJoker("red"));
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "BJ 2C 2D 4D AC 4C 5D 3C 3D AD 5C RJ";
 
     if (!result.equals(expected)) {
@@ -431,7 +458,7 @@ class Deck_count_cut_no_change_1 implements Runnable {
     deck.shuffle();
     deck.addCard(deck.new PlayingCard("clubs", 13));
     deck.countCut();
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "3C 3D AD 5C BJ 2C 2D 4D AC RJ 4C 5D KC";
 
     if (!result.equals(expected)) {
@@ -450,7 +477,7 @@ class Deck_count_cut_no_change_2 implements Runnable {
     deck.shuffle();
     deck.addCard(deck.new PlayingCard("clubs", 12));
     deck.countCut();
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "3C 3D AD 5C BJ 2C 2D 4D AC RJ 4C 5D QC";
 
     if (!result.equals(expected)) {
@@ -469,7 +496,7 @@ class Deck_count_cut_with_change implements Runnable {
     Deck.gen.setSeed(10);
     deck.shuffle();
     deck.countCut();
-    String result = deck.toString();
+    String result = Tester.deckToString(deck);
     String expected = "2D 4D AC RJ 4C 3C 3D AD 5C BJ 2C 5D";
 
     if (!result.equals(expected)) {
@@ -704,5 +731,23 @@ public class Tester {
     // Check that the list looped back to the head
     if (currentCard != deck.head)
       throw new AssertionError("The list did not loop back to the head after traversing all cards.");
+  }
+
+  /**
+   * Converts the given deck to a String, with one space between each card.
+   * 
+   * @param deck The deck to be converted to String
+   * @return A string listing all cards, separated by spaces
+   */
+  public static String deckToString(Deck deck) {
+    String out = "";
+    Deck.Card currentCard = deck.head;
+
+    for (int i = 0; i < deck.numOfCards; i++) {
+      out += currentCard.toString() + " ";
+      currentCard = currentCard.next;
+    }
+
+    return out.substring(0, out.length() - 1);
   }
 }

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -422,6 +422,9 @@ class Deck_triple_cut_regular implements Runnable {
       throw new AssertionError(
           "The resulting deck is " + result + " but should have been " + expected);
     }
+
+    Tester.checkReferences(deck);
+
     System.out.println("Deck regular triple cut test passed.");
   }
 }
@@ -442,6 +445,9 @@ class Deck_triple_cut_empty_end implements Runnable {
       throw new AssertionError(
           "The resulting deck is " + result + " but should have been " + expected);
     }
+
+    Tester.checkReferences(deck);
+
     System.out.println("Deck empty end triple cut test passed.");
   }
 }
@@ -462,6 +468,9 @@ class Deck_triple_cut_empty_start implements Runnable {
       throw new AssertionError(
           "The resulting deck is " + result + " but should have been " + expected);
     }
+
+    Tester.checkReferences(deck);
+
     System.out.println("Deck empty start triple cut test passed.");
   }
 }
@@ -483,6 +492,9 @@ class Deck_triple_cut_both_ends_empty implements Runnable {
       throw new AssertionError(
           "The resulting deck is " + result + " but should have been " + expected);
     }
+
+    Tester.checkReferences(deck);
+
     System.out.println("Deck both ends empty triple cut test passed.");
   }
 }

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -368,6 +368,9 @@ class Deck_move_card_no_change implements Runnable {
       throw new AssertionError(
           "The resulting deck is " + result + " but should have been " + expected);
     }
+
+    Tester.checkReferences(deck);
+
     System.out.println("Deck card move no change test passed.");
   }
 }
@@ -387,23 +390,10 @@ class Deck_move_card_with_change implements Runnable {
       throw new AssertionError(
           "The resulting deck is " + result + " but should have been " + expected);
     }
-    System.out.println("Deck card move with change test passed.");
-  }
-}
-
-
-class Deck_move_card_references implements Runnable {
-  @Override
-  public void run() {
-    Deck deck = new Deck(5, 2);
-    Deck.gen.setSeed(10);
-    deck.shuffle();
-    deck.moveCard(deck.locateJoker("red"), 1);
-    deck.moveCard(deck.locateJoker("black"), 2);
 
     Tester.checkReferences(deck);
 
-    System.out.println("Deck moveCard() references test passed.");
+    System.out.println("Deck card move with change test passed.");
   }
 }
 
@@ -710,7 +700,7 @@ public class Tester {
       "assignment2.Deck_Deck_too_few_suits",
       "assignment2.Deck_Deck_copy",
       "assignment2.Deck_Deck_deep_copy",
-      "assignment2.Deck_Deck_addCard",
+      "assignment2.Deck_addCard",
       "assignment2.Deck_numOfCards",
       "assignment2.Deck_shuffle",
       "assignment2.Deck_locate_joker",
@@ -718,7 +708,6 @@ public class Tester {
       "assignment2.Deck_locate_joker_no_jokers",
       "assignment2.Deck_move_card_no_change",
       "assignment2.Deck_move_card_with_change",
-      "assignment2.Deck_move_card_references",
       "assignment2.Deck_triple_cut_regular",
       "assignment2.Deck_triple_cut_empty_end",
       "assignment2.Deck_triple_cut_empty_start",

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -16,6 +16,9 @@ class Deck_Deck_one_card implements Runnable {
     if (!result.equals(expected)) {
       throw new AssertionError("new Deck(1, 1) returned " + result + " but expected " + expected);
     }
+
+    Tester.checkReferences(deck);
+
     System.out.println("One card deck test passed.");
   }
 }
@@ -31,16 +34,10 @@ class Deck_Deck_all_cards implements Runnable {
     if (!result.equals(expected)) {
       throw new AssertionError("new Deck(13, 4) returned " + result + " but expected " + expected);
     }
-    System.out.println("All cards deck test passed.");
-  }
-}
 
-class Deck_Deck_references implements Runnable {
-  @Override
-  public void run() {
-    Deck deck = new Deck(13, 4);
     Tester.checkReferences(deck);
-    System.out.println("Deck() references test passed");
+
+    System.out.println("All cards deck test passed.");
   }
 }
 
@@ -699,7 +696,6 @@ public class Tester {
   static String[] tests = {
       "assignment2.Deck_Deck_one_card",
       "assignment2.Deck_Deck_all_cards",
-      "assignment2.Deck_Deck_references",
       "assignment2.Deck_Deck_too_many_cards",
       "assignment2.Deck_Deck_too_few_cards",
       "assignment2.Deck_Deck_too_many_suits",

--- a/assignment2/Tester.java
+++ b/assignment2/Tester.java
@@ -161,6 +161,28 @@ class Deck_Deck_deep_copy implements Runnable {
     received = Tester.deckToString(deckCopy);
     if (!expected.equals(received))
       throw new AssertionError("The copied deck was changed when the original deck was changed");
+
+    System.out.println("Deck deep copy test passed.");
+  }
+}
+
+
+class Deck_addCard implements Runnable {
+  @Override
+  public void run() {
+    Deck deck = new Deck(1, 1);
+    String expected = "AC RJ BJ 5C";
+    deck.addCard(deck.new PlayingCard("clubs", 5));
+
+    // Check that list structure is ok
+    Tester.checkReferences(deck);
+
+    // Check that cards are in the right order
+    String received = Tester.deckToString(deck);
+    if (!received.equals(expected))
+      throw new AssertionError("Expected deck " + expected + " but received " + received);
+
+    System.out.println("Deck addCard() test passed.");
   }
 }
 
@@ -651,6 +673,7 @@ public class Tester {
       "assignment2.Deck_Deck_too_few_suits",
       "assignment2.Deck_Deck_copy",
       "assignment2.Deck_Deck_deep_copy",
+      "assignment2.Deck_Deck_addCard",
       "assignment2.Deck_numOfCards",
       "assignment2.Deck_shuffle",
       "assignment2.Deck_locate_joker",


### PR DESCRIPTION
It would probably be a good idea to verify that the deck's references are all consistent (card == card.next.prev and stuff like that), especially after operations like tripleCut() that involve updating a lot of links. I don't have my Deck code yet though, so I'm not confident that the test works properly. It would probably be a good idea to see that it does what it's supposed to before merging it.

I also wrote a utility method in Tester that converts a Deck to string and replaced all the instances of deck.toString() by Tester.deckToString(deck). We're not supposed to add public methods to the skeleton code, so it seems pretty important not to require extra methods in the tester.

There are also a few new tests (like checking that the deck copying method actually returns a deep copy that's fully independent of the original).